### PR TITLE
  fixed syntax error

### DIFF
--- a/intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
+++ b/intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
@@ -316,7 +316,7 @@
    ],
    "source": [
     "import numpy as np\n",
-    "np.set_printoptions(precision=8)",
+    "np.set_printoptions(precision=8)\n",
     "a = np.random.rand(4,3)\n",
     "a"
    ]
@@ -336,7 +336,7 @@
     }
    ],
    "source": [
-    "torch.set_printoptions(precision=8)",
+    "torch.set_printoptions(precision=8)\n",
     "b = torch.from_numpy(a)\n",
     "b"
    ]


### PR DESCRIPTION

🐛 added a space in execution count, 78 and 79

![typo](https://user-images.githubusercontent.com/57009004/115613572-37b18480-a2f5-11eb-8466-a00447779625.jpg)